### PR TITLE
Update Elasticsearch and Opensearch in integration tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -111,15 +111,15 @@ jobs:
           es-url: http://localhost:9200
         - es-distribution: elasticsearch
           es-major-version: 7
-          es-image: elasticsearch:7.17.3
+          es-image: elasticsearch:7.17.10
           es-url: http://localhost:9200
         - es-distribution: elasticsearch
           es-major-version: 8
-          es-image: elasticsearch:8.1.2
+          es-image: elasticsearch:8.7.1
           es-url: https://localhost:9200
         - es-distribution: opensearch
           es-major-version: 2
-          es-image: opensearchproject/opensearch:2.0.1
+          es-image: opensearchproject/opensearch:2.4.0
           es-url: https://localhost:9200
     steps:
     - uses: actions/checkout@v3

--- a/integ-tests/src/commonTest/kotlin/dev/evo/elasticmagic/ElasticsearchTransportTests.kt
+++ b/integ-tests/src/commonTest/kotlin/dev/evo/elasticmagic/ElasticsearchTransportTests.kt
@@ -25,10 +25,18 @@ class ElasticsearchTransportTests : TestBase() {
 
     @Test
     fun catRequest() = runTest {
-        val nodes = transport.request(CatRequest("nodes", errorSerde = JsonSerde))
+        val nodes = transport.request(
+            CatRequest(
+                "nodes",
+                parameters = mapOf(
+                    "h" to listOf("name,node.role,ip,heap.percent,cpu,master"),
+                ),
+                errorSerde = JsonSerde
+            )
+        )
         nodes.size shouldBe 1
-        nodes[0].size shouldBe 10
-        nodes[0][nodes[0].size - 2] shouldBe "*"
+        nodes[0].size shouldBe 6
+        nodes[0][nodes[0].size - 1] shouldBe "*"
     }
 
     @Test


### PR DESCRIPTION
- Elasticsearch 7 to 7.17.10
- Elasticsearch 8 to 8.7.1
- Opensearch 2 to 2.4.0